### PR TITLE
Fix problem with users hosting who aren't gamenight host+

### DIFF
--- a/ext/hosting.py
+++ b/ext/hosting.py
@@ -9,7 +9,7 @@ class Notifications(commands.Cog):
         self.bot = bot
 
     @commands.command()
-    @commands.has_any_role("Administrator", "Moderator", "Senior Moderator", "Gamenight Host")
+    @commands.has_any_role("admin (mosted hated/gay)", "Moderator", "Senior Moderator", "Gamenight Host", "Server Manager")
     async def host(self, ctx, mode, notification_type, *, gamemode='Not Defined'):
         """Pings the appropriate role for the appropriate game mode.
         Params:
@@ -54,7 +54,7 @@ class Notifications(commands.Cog):
         return await ctx.send(f'{ctx.author.mention}, your IGN was sent.')
 
     @commands.command(name='gamemodes')
-    @commands.has_any_role("Administrator", "Moderator", "Senior Moderator", "Gamenight Host")
+    @commands.has_any_role("admin (mosted hated/gay)", "Moderator", "Senior Moderator", "Gamenight Host", "Server Manager")
     async def gamemodes(self, ctx, mode):
         """Sends the message for each gamemode.
         Params

--- a/ext/hosting.py
+++ b/ext/hosting.py
@@ -9,6 +9,7 @@ class Notifications(commands.Cog):
         self.bot = bot
 
     @commands.command()
+    @commands.has_any_role("Administrator", "Moderator", "Senior Moderator", "Gamenight Host")
     async def host(self, ctx, mode, notification_type, *, gamemode='Not Defined'):
         """Pings the appropriate role for the appropriate game mode.
         Params:


### PR DESCRIPTION
# Pull Request

## Description

Makes only gamenight hosts and above use the host command.

<!--- Describe your changes in detail or not idc lmao -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix or improving code quality
- [X] Improving an existing feature
- [ ] New feature

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- The code style of this project is PEP8: https://www.python.org/dev/peps/pep-0008/ -->

- [X] My code follows the code style of this project.
- [X] I have updated the doc-strings (if existing/applicable) accordingly.
- [X] If a new command: I have created a docstrings with parameters in a format similar to the other commands.
